### PR TITLE
adding twitter api wrapper demo code from old repository

### DIFF
--- a/TwitterApiWrappersDemo/src/PremiumAPIWrapperDemo.py
+++ b/TwitterApiWrappersDemo/src/PremiumAPIWrapperDemo.py
@@ -1,0 +1,43 @@
+import os
+
+import searchtweets as st
+
+ENDPOINT_ENV_VAR = "SEARCHTWEETS_ENDPOINT"
+
+TWITTER_PREMIUM_API_ENDPOINT_FORMAT = "https://api.twitter.com/{}/tweets/search/{}/{}.json"
+TWITTER_API_VERSION = "1.1"
+MONTH_SEARCH_PRODUCT = "30day"
+FULL_ARCHIVE_SEARCH_PRODUCT = "fullarchive"
+MONTH_SEARCH_DEV_ENV_LABEL = "SSBase30DayEnv"
+FULL_ARCHIVE_SEARCH_DEV_ENV_LABEL = "SSBaseFullArchiveEnv"
+
+PREMIUM_30_DAY_ENDPOINT = TWITTER_PREMIUM_API_ENDPOINT_FORMAT.format(TWITTER_API_VERSION, MONTH_SEARCH_PRODUCT,
+                                                                     MONTH_SEARCH_DEV_ENV_LABEL)
+PREMIUM_FULL_ARCHIVE_ENDPOINT = TWITTER_PREMIUM_API_ENDPOINT_FORMAT.format(TWITTER_API_VERSION,
+                                                                           FULL_ARCHIVE_SEARCH_PRODUCT,
+                                                                           FULL_ARCHIVE_SEARCH_DEV_ENV_LABEL)
+
+
+def getPremiumEndpointCreds(endpointType):
+    """
+    fetches credentials for some premium endpoint using an api key and secret
+    which are already in the system's environment variables
+    :parameter endpointType which premium endpoint to get the credentials for (30 day or full archive)
+    :return credentials for some premium endpoint
+    """
+    os.environ[ENDPOINT_ENV_VAR] = endpointType;
+    searchArgs = st.load_credentials(filename="NoCredsFile.yaml", account_type="premium", yaml_key="dummyYamlKey")
+    # cleaning up this temporary environment variable to avoid causing a side effect
+    del os.environ[ENDPOINT_ENV_VAR]
+
+    return searchArgs
+
+
+if __name__ == '__main__':
+    print("running search-tweets demo program")
+    monthSearchArgs = getPremiumEndpointCreds(PREMIUM_30_DAY_ENDPOINT)
+
+    # max_results must stay 100 b/c we're using a sandbox account
+    coronavirusRule = st.gen_rule_payload("lang:en coronavirus", from_date="2020-02-01")
+    tweets = st.collect_results(coronavirusRule, max_results=100, result_stream_args=monthSearchArgs)
+    [print(tweet.all_text, end="\n") for tweet in tweets[0:50]]

--- a/TwitterApiWrappersDemo/src/StandardAPIWrapperDemo.py
+++ b/TwitterApiWrappersDemo/src/StandardAPIWrapperDemo.py
@@ -1,0 +1,40 @@
+import tweepy
+
+import src.TwitterCredentialManagement as tcm
+
+TEST_TWITTER_USERNAME = "ScottSSalisbur1"
+
+if __name__ == '__main__':
+    print("running tweepy demo program")
+
+    apiKey, apiSecretKey, accessToken, accessTokenSecret = tcm.fetchApiCredentials()
+
+    auth = tweepy.OAuthHandler(apiKey, apiSecretKey)
+    auth.set_access_token(accessToken, accessTokenSecret)
+
+    twitterStandardApi = tweepy.API(auth)
+
+    try:
+        twitterStandardApi.verify_credentials()
+        print("Twitter credentials valid")
+    except:
+        print("Tweepy unable to authenticate with Twitter")
+
+    user = twitterStandardApi.get_user(TEST_TWITTER_USERNAME)
+    print("Test User Details:")
+    print("Account creation date= " + str(user.created_at))
+    print("ID String= " + user.id_str)
+
+
+    print("\n\nTrend information:")
+    worldwideLocCode= 1
+    trendsResult = twitterStandardApi.trends_place(worldwideLocCode)
+    for trend in trendsResult[0]["trends"]:
+        trendName = trend["name"]
+        trendPop = trend["tweet_volume"]
+        if trendPop is None:
+            trendPop = "unknown number of"
+        else:
+            trendPop = str(trendPop)
+
+        print("Trend " + trend["name"] + " was used in " + trendPop + " tweets")

--- a/TwitterApiWrappersDemo/src/TwitterCredentialManagement.py
+++ b/TwitterApiWrappersDemo/src/TwitterCredentialManagement.py
@@ -1,0 +1,28 @@
+import os
+
+API_KEY_ENV_VAR_NAME = "TWITTER_TRENDS_API_KEY"
+API_SECRET_KEY_ENV_VAR_NAME = "TWITTTER_TRENDS_API_SECRET_KEY"
+ACCESS_TOKEN_ENV_VAR_NAME = "TWITTER_TRENDS_ACCESS_TOKEN"
+ACCESS_TOKEN_SECRET_ENV_VAR_NAME = "TWITTER_TRENDS_ACCESS_TOKEN_SECRET"
+
+missingEnvVarErrorStr = "{} environment variable is not defined"
+
+
+def fetchApiCredentials():
+    """
+    loads standard api credentials from where they're stored in system environment variables
+    :return: credentials for the standard api
+    """
+    apiKey = os.environ.get(API_KEY_ENV_VAR_NAME)
+    assert apiKey != None, missingEnvVarErrorStr.format("API Key")
+
+    apiSecretKey = os.environ.get(API_SECRET_KEY_ENV_VAR_NAME)
+    assert apiSecretKey != None, missingEnvVarErrorStr.format("API Secret Key")
+
+    accessToken = os.environ.get(ACCESS_TOKEN_ENV_VAR_NAME)
+    assert accessToken != None, missingEnvVarErrorStr.format("API Access Token")
+
+    accessTokenSecret = os.environ.get(ACCESS_TOKEN_SECRET_ENV_VAR_NAME)
+    assert accessTokenSecret != None, missingEnvVarErrorStr.format("API Access Token Secret")
+
+    return apiKey, apiSecretKey, accessToken, accessTokenSecret


### PR DESCRIPTION
It was added in a feature branch twitterApiDemo with the following commit messages:

* create project for making Proof of concept uses of twitter api wrapper libraries
* add credential management helper and implement working POC for getting twitter user data
* added trend fetching PoC
* successfully formed connection to premium api endpoint
* added PoC for fetching tweets with premium 30 day search
* adding documentation to functions